### PR TITLE
Legg til komponenter for rettigheter og plikter

### DIFF
--- a/components/forsiden/guidepanel.module.css
+++ b/components/forsiden/guidepanel.module.css
@@ -1,0 +1,13 @@
+.rettigheter {
+    --navds-guide-panel-color-border: var(--navds-global-color-green-200);
+    --navds-guide-panel-color-illustration-background: var(
+            --navds-global-color-green-200
+    );
+}
+
+.plikter {
+    --navds-guide-panel-color-border: var(--navds-global-color-orange-200);
+    --navds-guide-panel-color-illustration-background: var(
+            --navds-global-color-orange-200
+    );
+}

--- a/components/forsiden/plikter.tsx
+++ b/components/forsiden/plikter.tsx
@@ -1,0 +1,27 @@
+import lagHentTekstForSprak, { Tekster } from '../../lib/lag-hent-tekst-for-sprak';
+import useSprak from '../../hooks/useSprak';
+import { BodyShort, GuidePanel, Heading } from '@navikt/ds-react';
+import styles from './guidepanel.module.css';
+
+const TEKSTER: Tekster<string> = {
+    nb: {
+        tittel: 'Plikter',
+        sendeMeldekort: 'Du må sende meldekort hver 14. dag. Det er et krav for å få oppfølging og økonomisk støtte.',
+        aktivArbeidssoker: 'Du må være aktiv arbeidssøker, søke på ledige stillinger og holde CV-en oppdatert.',
+    },
+};
+
+const PlikterPanel = () => {
+    const tekst = lagHentTekstForSprak(TEKSTER, useSprak());
+    return (
+        <GuidePanel className={styles.plikter} poster>
+            <Heading size={'small'}>{tekst('tittel')}</Heading>
+            <ul>
+                <li>{tekst('sendeMeldekort')}</li>
+                <li>{tekst('aktivArbeidssoker')}</li>
+            </ul>
+        </GuidePanel>
+    );
+};
+
+export default PlikterPanel;

--- a/components/forsiden/rettigheter.tsx
+++ b/components/forsiden/rettigheter.tsx
@@ -1,0 +1,29 @@
+import { BodyShort, GuidePanel, Heading } from '@navikt/ds-react';
+import styles from './guidepanel.module.css';
+import lagHentTekstForSprak, { Tekster } from '../../lib/lag-hent-tekst-for-sprak';
+import useSprak from '../../hooks/useSprak';
+
+const TEKSTER: Tekster<string> = {
+    nb: {
+        tittel: 'Rettigheter',
+        kravPaVurdering:
+            'Du har krav på at NAV vurderer behovet ditt for veiledning. Dette er en rettighet du har etter NAV-loven § 14a.',
+        brev: 'Du får et brev der du kan lese mer om tjenestene vi foreslår for deg.',
+    },
+};
+
+const RettigheterPanel = () => {
+    const tekst = lagHentTekstForSprak(TEKSTER, useSprak());
+
+    return (
+        <GuidePanel className={styles.rettigheter} poster>
+            <Heading size={'small'}>{tekst('tittel')}</Heading>
+            <ul>
+                <li>{tekst('kravPaVurdering')}</li>
+                <li>{tekst('brev')}</li>
+            </ul>
+        </GuidePanel>
+    );
+};
+
+export default RettigheterPanel;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,13 @@
 import type { NextPage } from 'next';
 import Head from 'next/head';
-import { Button, Heading } from '@navikt/ds-react';
+import { Button, Cell, Grid, Heading } from '@navikt/ds-react';
 import lagHentTekstForSprak, { Tekster } from '../lib/lag-hent-tekst-for-sprak';
 import useSprak from '../hooks/useSprak';
 import DineOpplysninger from '../components/forsiden/dine-opplysninger';
 import NextLink from 'next/link';
 import { SkjemaSide } from '../model/skjema';
+import RettigheterPanel from '../components/forsiden/rettigheter';
+import PlikterPanel from '../components/forsiden/plikter';
 
 const TEKSTER: Tekster<string> = {
     nb: {
@@ -42,7 +44,17 @@ const Home: NextPage = (props) => {
                     <Button variant="secondary">Sykmeldt registrering</Button>
                 </NextLink>
             </p>
-            <DineOpplysninger />
+            <Grid>
+                <Cell xs={12} md={6}>
+                    <RettigheterPanel />
+                </Cell>
+                <Cell xs={12} md={6}>
+                    <PlikterPanel />
+                </Cell>
+                <Cell xs={12}>
+                    <DineOpplysninger />
+                </Cell>
+            </Grid>
         </div>
     );
 };


### PR DESCRIPTION
Førsteutkast av guidepanelene med rettigheter og plikter. Mangler grå bakgrunn, tilpassede illustrasjoner og får ulik høyde når antall linjer tekst blir forskjellig. Kanskje droppe Grid her og bruke flex i stedet? 🤷‍♀️ 