### PR TITLE
Sjekk om registreringen feiler før evt. videresending til aia

### DIFF
--- a/components/skjema/fullforRegistrering.tsx
+++ b/components/skjema/fullforRegistrering.tsx
@@ -17,6 +17,7 @@ import { DinSituasjon, SporsmalId } from '../../model/sporsmal';
 import { useFeatureToggles } from '../../contexts/featuretoggle-context';
 import { useConfig } from '../../contexts/config-context';
 import { Config } from '../../model/config';
+import { hentRegistreringFeiletUrl } from '../../lib/hent-registrering-feilet-url';
 
 const TEKSTER: Tekster<string> = {
     nb: {
@@ -117,6 +118,12 @@ const FullforRegistrering = (props: FullforProps) => {
                     dinSituasjon
                 );
 
+            const feiltype = response.type;
+
+            if (feiltype) {
+                return hentRegistreringFeiletUrl(feiltype);
+            }
+
             const skalHoppeOverKvittering =
                 erStandardInnsatsgruppe &&
                 harMistetJobbSagtOppEllerPermittert &&
@@ -141,7 +148,7 @@ const FullforRegistrering = (props: FullforProps) => {
 
                 return router.push(`${dittNavUrl}?goTo=registrering`);
             }
-            return router.push(hentKvitteringsUrl(response, props.side));
+            return router.push(hentKvitteringsUrl(props.side));
         } catch (e) {
             settVisFeilmeldingTeller(visFeilmeldingTeller + 1);
             settVisFeilmelding(true);

--- a/lib/hent-kvitterings-url.test.ts
+++ b/lib/hent-kvitterings-url.test.ts
@@ -2,31 +2,11 @@ import hentKvitteringsUrl from './hent-kvitterings-url';
 import { ErrorTypes } from '../model/error';
 
 describe('hent-kvitterings-url', () => {
-    it('returnerer "/veiledning/utvandret/" for død, utvandret eller forsvunnet bruker', () => {
-        expect(hentKvitteringsUrl({ type: ErrorTypes.BRUKER_ER_DOD_UTVANDRET_ELLER_FORSVUNNET })).toBe(
-            '/veiledning/utvandret/'
-        );
-    });
-
-    it('returnerer "/veiledning/mangler-arbeidstillatelse/" for bruker som mangler arbeidstillatelse', () => {
-        expect(hentKvitteringsUrl({ type: ErrorTypes.BRUKER_MANGLER_ARBEIDSTILLATELSE })).toBe(
-            '/veiledning/mangler-arbeidstillatelse/'
-        );
-    });
-
-    it('returnerer "/feil/" for ukjent bruker', () => {
-        expect(hentKvitteringsUrl({ type: ErrorTypes.BRUKER_ER_UKJENT })).toBe('/feil/');
-    });
-
-    it('returnerer "/feil/" for bruker som ikke kan reaktiveres', () => {
-        expect(hentKvitteringsUrl({ type: ErrorTypes.BRUKER_KAN_IKKE_REAKTIVERES })).toBe('/feil/');
-    });
-
     it('returnerer "/kvittering/" for responser uten type', () => {
         expect(hentKvitteringsUrl()).toBe('/kvittering/');
     });
 
     it('returnerer "/kvittering-sykmeldt/ for sykmeldt-side', () => {
-        expect(hentKvitteringsUrl({}, 'sykmeldt')).toBe('/kvittering-sykmeldt/');
+        expect(hentKvitteringsUrl('sykmeldt')).toBe('/kvittering-sykmeldt/');
     });
 });

--- a/lib/hent-kvitterings-url.ts
+++ b/lib/hent-kvitterings-url.ts
@@ -1,17 +1,5 @@
-import { ErrorTypes } from '../model/error';
-import { FullforRegistreringResponse } from '../model/registrering';
 import { Side } from '../model/skjema';
 
-export default function hentKvitteringsUrl(response: FullforRegistreringResponse = {}, side: Side = 'standard') {
-    const { type } = response;
-
-    if (type === ErrorTypes.BRUKER_ER_DOD_UTVANDRET_ELLER_FORSVUNNET) {
-        return '/veiledning/utvandret/';
-    } else if (response.type === ErrorTypes.BRUKER_MANGLER_ARBEIDSTILLATELSE) {
-        return '/veiledning/mangler-arbeidstillatelse/';
-    } else if (type && [ErrorTypes.BRUKER_ER_UKJENT, ErrorTypes.BRUKER_KAN_IKKE_REAKTIVERES].includes(type)) {
-        return '/feil/';
-    }
-
+export default function hentKvitteringsUrl(side: Side = 'standard') {
     return side === 'sykmeldt' ? '/kvittering-sykmeldt/' : '/kvittering/';
 }

--- a/lib/hent-registrering-feilet-url.test.ts
+++ b/lib/hent-registrering-feilet-url.test.ts
@@ -1,0 +1,24 @@
+import { hentRegistreringFeiletUrl } from './hent-registrering-feilet-url';
+import { ErrorTypes } from '../model/error';
+
+describe('hent-registrering-feilet-url', () => {
+    it('returnerer "/veiledning/utvandret/" for død, utvandret eller forsvunnet bruker', () => {
+        expect(hentRegistreringFeiletUrl(ErrorTypes.BRUKER_ER_DOD_UTVANDRET_ELLER_FORSVUNNET)).toBe(
+            '/veiledning/utvandret/'
+        );
+    });
+
+    it('returnerer "/veiledning/mangler-arbeidstillatelse/" for bruker som mangler arbeidstillatelse', () => {
+        expect(hentRegistreringFeiletUrl(ErrorTypes.BRUKER_MANGLER_ARBEIDSTILLATELSE)).toBe(
+            '/veiledning/mangler-arbeidstillatelse/'
+        );
+    });
+
+    it('returnerer "/feil/" for ukjent bruker', () => {
+        expect(hentRegistreringFeiletUrl(ErrorTypes.BRUKER_ER_UKJENT)).toBe('/feil/');
+    });
+
+    it('returnerer "/feil/" for bruker som ikke kan reaktiveres', () => {
+        expect(hentRegistreringFeiletUrl(ErrorTypes.BRUKER_KAN_IKKE_REAKTIVERES)).toBe('/feil/');
+    });
+});

--- a/lib/hent-registrering-feilet-url.ts
+++ b/lib/hent-registrering-feilet-url.ts
@@ -1,0 +1,11 @@
+import { ErrorTypes } from '../model/error';
+
+export const hentRegistreringFeiletUrl = (feiltype: ErrorTypes) => {
+    if (feiltype === ErrorTypes.BRUKER_ER_DOD_UTVANDRET_ELLER_FORSVUNNET) {
+        return '/veiledning/utvandret/';
+    } else if (feiltype === ErrorTypes.BRUKER_MANGLER_ARBEIDSTILLATELSE) {
+        return '/veiledning/mangler-arbeidstillatelse/';
+    } else if (feiltype && [ErrorTypes.BRUKER_ER_UKJENT, ErrorTypes.BRUKER_KAN_IKKE_REAKTIVERES].includes(feiltype)) {
+        return '/feil/';
+    }
+};


### PR DESCRIPTION
Vi sjekket etter registreringsfeil (bruker er utvandret osv.) inni funksjonen hentKvitteringsUrl.
Nå har vi lagt til videresending til AIA/Veien til arbeid i stedet for kvittering for visse brukere, og denne videresendingen skjedde før hentKvitteringsUrl ble kjørt. Dermed hoppet vi over feilhåndteringen for disse brukerne.
Flytta derfor henting av url-er som skal brukes når registreringen feiler til en egen funksjon som kjører før videresending.