### PR TITLE
innfører BRUKER_KAN_IKKE_REAKTIVERES_FORENKLET

### DIFF
--- a/docs/metrikker.md
+++ b/docs/metrikker.md
@@ -23,6 +23,10 @@ På situasjonen `Arbeidssøkeren må reaktivere seg` kan du også gruppere på `
 Arbeidssøkeren har falt ut av NAV-systemet og det har gått kortere tid enn 28 dager siden det skjedde.
 Her er det mulig å gruppere på `brukergruppe` for å se hvilken status arbeidssøkeren hadde før hen falt ut.
 
+`Arbeidssøkeren får ikke reaktivert seg`
+Arbeidssøkeren har satt igang reaktivering, men får en feilmelding tilbake.
+Her er det mulig å grupper på `aarsak` for å se hvilken feil baksystemet gir
+
 `Arbeidssøkeren mangler arbeidstillatelse eller er utvandret`
 
 Denne kan skyldes at NAV ikke har oppdaterte opplysninger om arbeidssøkeren i vår systemer.

--- a/lib/amplitude.ts
+++ b/lib/amplitude.ts
@@ -1,6 +1,8 @@
 import amplitude from 'amplitude-js';
+
 import { Brukergruppe, RegistreringType } from '../model/registrering';
 import { DinSituasjon, SporsmalId } from '../model/sporsmal';
+import { ErrorTypes } from '../model/error';
 
 const isBrowser = () => typeof window !== 'undefined';
 
@@ -18,7 +20,7 @@ type EventData = SidevisningData | AktivitetData | StoppsituasjonData | Besvarel
 
 type BesvarelseData = { skjematype: 'standard' | 'sykmeldt'; sporsmalId: SporsmalId; svar: any };
 
-type StoppsituasjonData = { situasjon: string; brukergruppe?: Brukergruppe };
+type StoppsituasjonData = { situasjon: string; brukergruppe?: Brukergruppe; aarsak?: ErrorTypes };
 
 type SidevisningData = { sidetittel: string };
 

--- a/pages/api/reaktivering.ts
+++ b/pages/api/reaktivering.ts
@@ -1,14 +1,18 @@
-import { NextApiRequest, NextApiResponse } from 'next';
-import lagApiHandlerMedAuthHeaders from '../../lib/next-api-handler';
+import { ApiError, lagApiPostHandlerMedAuthHeaders } from '../../lib/next-api-handler';
 
 const reaktiveringUrl = `${process.env.REAKTIVERING_URL}`;
 
-const reaktiveringHandler = (req: NextApiRequest, res: NextApiResponse) => {
-    if (req.method === 'POST') {
-        return lagApiHandlerMedAuthHeaders(reaktiveringUrl)(req, res);
+const errorHandler = (response: Response) => {
+    const contentType = response.headers.get('content-type');
+    if (contentType && contentType.includes('application/json')) {
+        return response.json();
     } else {
-        return res.status(405).end();
+        const error = new Error(response.statusText) as ApiError;
+        error.status = response.status;
+        throw error;
     }
 };
+
+const reaktiveringHandler = lagApiPostHandlerMedAuthHeaders(reaktiveringUrl, errorHandler);
 
 export default reaktiveringHandler;

--- a/pages/reaktivering.tsx
+++ b/pages/reaktivering.tsx
@@ -6,7 +6,6 @@ import useSWR from 'swr';
 import lagHentTekstForSprak, { Tekster } from '../lib/lag-hent-tekst-for-sprak';
 import useSprak from '../hooks/useSprak';
 import { fetcher as api } from '../lib/api-utils';
-import { useErrorContext } from '../contexts/error-context';
 import { Brukergruppe } from '../model/registrering';
 import { loggStoppsituasjon, loggAktivitet } from '../lib/amplitude';
 import { fetcher } from '../lib/api-utils';
@@ -27,7 +26,6 @@ const Reaktivering = () => {
     const sprak = useSprak();
     const tekst = lagHentTekstForSprak(TEKSTER, sprak);
     const router = useRouter();
-    const { medFeilHandtering } = useErrorContext();
     const { data, error } = useSWR('api/startregistrering/', fetcher);
     const [brukergruppe, setBrukergruppe] = useState(Brukergruppe.UKJENT);
 
@@ -38,10 +36,20 @@ const Reaktivering = () => {
 
     const reaktiverBruker = async () => {
         loggAktivitet({ aktivitet: 'Arbeidssøkeren reaktiverer seg', brukergruppe });
-        medFeilHandtering(async () => {
-            await api('/api/reaktivering/', { method: 'post', body: JSON.stringify({}) });
+
+        console.log('Vi reaktiverer bruker');
+
+        const response = await api('api/reaktivering/', { method: 'post', body: JSON.stringify({}) });
+
+        if (response.type) {
+            loggStoppsituasjon({
+                situasjon: 'Arbeidssøkeren får ikke reaktivert seg',
+                aarsak: response.type,
+            });
+            router.push('/feil/');
+        } else {
             return router.push('/kvittering-reaktivering/');
-        });
+        }
     };
 
     useEffect(() => {

--- a/pages/reaktivering.tsx
+++ b/pages/reaktivering.tsx
@@ -37,8 +37,6 @@ const Reaktivering = () => {
     const reaktiverBruker = async () => {
         loggAktivitet({ aktivitet: 'Arbeidssøkeren reaktiverer seg', brukergruppe });
 
-        console.log('Vi reaktiverer bruker');
-
         const response = await api('api/reaktivering/', { method: 'post', body: JSON.stringify({}) });
 
         if (response.type) {


### PR DESCRIPTION
I forbindelse med reaktivering kan man i noen tilfeller treffe feilen BRUKER_KAN_IKKE_REAKTIVERES_FORENKLET.

I denne PR legger vi inn feiltypen og legger opp til å kunne behandle feilen separat, selv om i første omgang logger vi bare stoppsituasjonen til Amplitude.