### PR TITLE
Flytter demo fra labs til ekstern.dev

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,11 +94,10 @@ jobs:
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: labs-gcp
+          CLUSTER: dev-gcp
           RESOURCE: .nais/nais-labs.yaml
           VARS: .nais/demo.yaml
           PRINT_PAYLOAD: true
-          DEPLOY_SERVER: deploy.nais.io:443
 
   deploy-dev:
     name: Deploy to dev

--- a/.nais/demo.yaml
+++ b/.nais/demo.yaml
@@ -1,4 +1,4 @@
-ingress: https://arbeid.labs.nais.io/arbeid/registrering
+ingress: https://arbeid.ekstern.dev.nav.no/arbeid/registrering
 basePath: /arbeid/registrering
 mocking: enabled
 nodeEnv: development
@@ -9,18 +9,18 @@ amplitude:
   apiKey: 9845ded64c69cd068651cd0d968e0796
   endPoint: amplitude.nav.no/collect
 pamJanzzUrl: https://arbeidsplassen.nav.no/pam-janzz/rest
-startUrl: https://arbeid.labs.nais.io/arbeid/registrering/start
-startRegistreringUrl: https://arbeid.labs.nais.io/arbeid/registrering/api/mocks/startregistrering
-fullforRegistreringUrl: https://arbeid.labs.nais.io/arbeid/registrering/api/mocks/fullforregistrering
-fullforRegistreringSykmeldtUrl: https://arbeid.labs.nais.io/arbeid/registrering/api/mocks/fullforregistreringsykmeldt
-reaktiveringUrl: https://arbeid.labs.nais.io/arbeid/registrering/api/mocks/reaktivering
-sisteArbeidsforholdUrl: https://arbeid.labs.nais.io/arbeid/registrering/api/mocks/sistearbeidsforhold
-opprettOppgaveUrl: https://arbeid.labs.nais.io/arbeid/registrering/api/mocks/oppgave
-kontaktinformasjonUrl: https://arbeid.labs.nais.io/arbeid/registrering/api/mocks/kontaktinformasjon
+startUrl: https://arbeid.ekstern.dev.nav.no/arbeid/registrering/start
+startRegistreringUrl: https://arbeid.ekstern.dev.nav.no/arbeid/registrering/api/mocks/startregistrering
+fullforRegistreringUrl: https://arbeid.ekstern.dev.nav.no/arbeid/registrering/api/mocks/fullforregistrering
+fullforRegistreringSykmeldtUrl: https://arbeid.ekstern.dev.nav.no/arbeid/registrering/api/mocks/fullforregistreringsykmeldt
+reaktiveringUrl: https://arbeid.ekstern.dev.nav.no/arbeid/registrering/api/mocks/reaktivering
+sisteArbeidsforholdUrl: https://arbeid.ekstern.dev.nav.no/arbeid/registrering/api/mocks/sistearbeidsforhold
+opprettOppgaveUrl: https://arbeid.ekstern.dev.nav.no/arbeid/registrering/api/mocks/oppgave
+kontaktinformasjonUrl: https://arbeid.ekstern.dev.nav.no/arbeid/registrering/api/mocks/kontaktinformasjon
 dittNAVUrl: https://www.nav.no/minside
 dagpengesoknadUrl: https://www.nav.no/dagpenger/dialog/soknad
 dialogUrl: https://www.nav.no/arbeid/dialog
 featureToggles:
-  server: https://arbeid.labs.nais.io/arbeid/registrering/api/mocks/features
-  client: https://arbeid.labs.nais.io/arbeid/registrering/api/features
-hentProfileringUrl: https://arbeid.labs.nais.io/arbeid/registrering/api/mocks/profilering
+  server: https://arbeid.ekstern.dev.nav.no/arbeid/registrering/api/mocks/features
+  client: https://arbeid.ekstern.dev.nav.no/arbeid/registrering/api/features
+hentProfileringUrl: https://arbeid.ekstern.dev.nav.no/arbeid/registrering/api/mocks/profilering

--- a/.nais/nais-labs.yaml
+++ b/.nais/nais-labs.yaml
@@ -1,7 +1,7 @@
 apiVersion: "nais.io/v1alpha1"
 kind: "Application"
 metadata:
-  name: "poa-arbeidssokerregistrering"
+  name: "arbeidssokerregistrering-demo"
   namespace: "paw"
   labels:
     "team": "paw"
@@ -15,8 +15,8 @@ spec:
     path: "{{basePath}}/api/isready"
     initialDelay: 3
   replicas:
-    min: 2
-    max: 2
+    min: 1
+    max: 1
     cpuThresholdPercentage: 50
   prometheus:
     enabled: false
@@ -75,3 +75,7 @@ spec:
       value: {{hentProfileringUrl}}
   ingresses:
     - {{ingress}}
+  accessPolicy:
+    outbound:
+      external:
+        - host: arbeidsplassen.nav.no

--- a/.nais/nais-labs.yaml
+++ b/.nais/nais-labs.yaml
@@ -79,3 +79,5 @@ spec:
     outbound:
       external:
         - host: arbeidsplassen.nav.no
+        - host: arbeid.ekstern.dev.nav.no
+        - host: dekoratoren.ekstern.dev.nav.no

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Arbeidssøkerregistrering
 
 ## Demo
 
-[https://arbeid.labs.nais.io/arbeid/registrering](https://arbeid.labs.nais.io/arbeid/registrering)
+[https://arbeid.ekstern.dev.nav.no/arbeid/registrering](https://arbeid.ekstern.dev.nav.no/arbeid/registrering)
 
 # Utvikling
 


### PR DESCRIPTION
labs er lagt ned så vi flytter demoversjonen av registreringen til arbeid.ekstern.dev.nav.no