### PR TITLE
Legg til .ansatt url for nais demo og dev .yaml

### DIFF
--- a/.nais/demo.yaml
+++ b/.nais/demo.yaml
@@ -62,6 +62,7 @@ spec:
       value: development
   ingresses:
     - https://arbeid.ekstern.dev.nav.no/arbeid/registrering
+    - https://arbeid.ansatt.dev.nav.no/arbeid/registrering
   accessPolicy:
     outbound:
       rules:

--- a/.nais/dev-gcp/nais.yaml
+++ b/.nais/dev-gcp/nais.yaml
@@ -79,6 +79,7 @@ spec:
     - secret: poa-arbeidssokerregistrering-unleash-api-token
   ingresses:
     - https://arbeid.intern.dev.nav.no/arbeid/registrering
+    - https://arbeid.ansatt.dev.nav.no/arbeid/registrering
   idporten:
     enabled: true
     sidecar:


### PR DESCRIPTION
Legg til .ansatt ingress slik at det er mulig å registrere en testbruker i test som arbeidssøker uten nais-device.