### PR TITLE
bruk server side next variable for å sjekke mock

### DIFF
--- a/.nais/dev-gcp/nais.yaml
+++ b/.nais/dev-gcp/nais.yaml
@@ -52,6 +52,8 @@ spec:
       value: https://amplitude.nav.no/collect
     - name: NEXT_PUBLIC_ENABLE_MOCK
       value: disabled
+    - name: ENABLE_MOCK
+      value: disabled
     - name: NEXT_PUBLIC_DITTNAV_URL
       value: https://www.ansatt.dev.nav.no/minside
     - name: NEXT_PUBLIC_ARBEIDSSOEKERREGISTERET_URL

--- a/.nais/prod-gcp/nais.yaml
+++ b/.nais/prod-gcp/nais.yaml
@@ -49,6 +49,8 @@ spec:
       value: https://amplitude.nav.no/collect
     - name: NEXT_PUBLIC_ENABLE_MOCK
       value: disabled
+    - name: ENABLE_MOCK
+      value: disabled
     - name: NEXT_PUBLIC_DITTNAV_URL
       value: https://www.nav.no/minside
     - name: NEXT_PUBLIC_ARBEIDSSOEKERREGISTERET_URL

--- a/src/app/oppdater-opplysninger/api.ts
+++ b/src/app/oppdater-opplysninger/api.ts
@@ -11,8 +11,8 @@ import {
 } from '@navikt/arbeidssokerregisteret-utils';
 import { nanoid } from 'nanoid';
 import { mockApiResponse } from '@/app/oppdater-opplysninger/mock-data';
+import { brukerMock } from '@/config/env';
 
-const brukerMock = process.env.NEXT_PUBLIC_ENABLE_MOCK === 'enabled';
 const PERIODER_URL = `${process.env.ARBEIDSSOKERREGISTERET_OPPSLAG_API_V2_URL}/api/v1/arbeidssoekerperioder`;
 const OPPLYSNINGER_URL = `${process.env.ARBEIDSSOKERREGISTERET_OPPSLAG_API_V2_URL}/api/v1/opplysninger-om-arbeidssoeker`;
 

--- a/src/app/start/api.ts
+++ b/src/app/start/api.ts
@@ -1,7 +1,7 @@
+import { brukerMock } from '@/config/env';
 import { arbeidssokerApiKall } from '@/lib/arbeidssoker-api-kall';
 
 const url = `${process.env.INNGANG_API_URL}/api/v2/arbeidssoker/kanStartePeriode`;
-const brukerMock = process.env.ENABLE_MOCK === 'enabled';
 
 export async function fetchKanStartePeriode(): Promise<{ data?: any; error?: any }> {
     if (brukerMock) {

--- a/src/auth/withAuthentication.ts
+++ b/src/auth/withAuthentication.ts
@@ -2,11 +2,10 @@ import { GetServerSidePropsContext, GetServerSidePropsResult, NextApiRequest, Ne
 import { validateIdportenToken } from '@navikt/oasis';
 import { logger } from '@navikt/next-logger';
 import localeTilUrl from '../lib/locale-til-url';
+import { brukerMock } from '@/config/env';
 
 type PageHandler = (context: GetServerSidePropsContext) => Promise<GetServerSidePropsResult<unknown>>;
 type ApiHandler = (req: NextApiRequest, res: NextApiResponse) => Promise<unknown> | unknown;
-
-const brukerMock = process.env.NEXT_PUBLIC_ENABLE_MOCK === 'enabled';
 
 /**
  * Used to authenticate Next.JS pages. Assumes application is behind

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,3 @@
+const brukerMock = process.env.ENABLE_MOCK === 'enabled';
+
+export { brukerMock };

--- a/src/lib/lag-arbeidssoker-api-kall.ts
+++ b/src/lib/lag-arbeidssoker-api-kall.ts
@@ -4,8 +4,7 @@ import { verifyToken } from '../auth/token-validation';
 import { decodeJwt } from 'jose';
 import { logger } from '@navikt/next-logger';
 import { NextApiHandler } from 'next';
-
-const brukerMock = process.env.NEXT_PUBLIC_ENABLE_MOCK === 'enabled';
+import { brukerMock } from '@/config/env';
 
 type Opts = {
     method: 'PUT' | 'POST' | 'GET' | 'DELETE';

--- a/src/lib/next-api-handler.ts
+++ b/src/lib/next-api-handler.ts
@@ -2,6 +2,7 @@ import { NextApiHandler, NextApiRequest } from 'next';
 import { nanoid } from 'nanoid';
 import { logger } from '@navikt/next-logger';
 import { requestTokenxOboToken } from '@navikt/oasis';
+import { brukerMock } from '@/config/env';
 
 export const getHeaders = (token: string, callId: string) => {
     return {
@@ -61,8 +62,6 @@ export const getTokenFromRequest = (req: NextApiRequest) => {
     const bearerToken = req.headers['authorization'];
     return bearerToken?.replace('Bearer ', '');
 };
-
-const brukerMock = process.env.NEXT_PUBLIC_ENABLE_MOCK === 'enabled';
 
 export const getAaregToken = async (req: NextApiRequest) => {
     return getTokenXToken(req, AAREG_CLIENT_ID);

--- a/src/pages/api/config.ts
+++ b/src/pages/api/config.ts
@@ -12,7 +12,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         arbeidssoekerregisteretUrl: process.env.NEXT_PUBLIC_ARBEIDSSOEKERREGISTERET_URL!,
         dagpengesoknadUrl: process.env.NEXT_PUBLIC_DAGPENGESOKNAD_URL!,
         dialogUrl: process.env.NEXT_PUBLIC_DIALOG_URL!,
-        enableMock: process.env.NEXT_PUBLIC_ENABLE_MOCK!,
+        enableMock: process.env.NEXT_PUBLIC_ENABLE_MOCK,
         loginUrl: `${process.env.NEXT_PUBLIC_SELF_URL}/oauth2/login?redirect=${process.env.NEXT_PUBLIC_START_URL}`,
         aarsTall: new Date().getFullYear(),
     } as Config);

--- a/src/pages/api/features.ts
+++ b/src/pages/api/features.ts
@@ -3,8 +3,7 @@ import { logger } from '@navikt/next-logger';
 import { getDefinitions } from '@unleash/nextjs';
 
 import { mockToggles } from './mocks/features';
-
-const brukerMock = process.env.NEXT_PUBLIC_ENABLE_MOCK === 'enabled';
+import { brukerMock } from '@/config/env';
 
 export async function hentFeatures() {
     return brukerMock ? mockToggles : await getDefinitions();

--- a/src/pages/api/hent-siste-opplysninger.ts
+++ b/src/pages/api/hent-siste-opplysninger.ts
@@ -7,8 +7,8 @@ import {
     hentSisteOpplysningerOmArbeidssoker,
 } from '@navikt/arbeidssokerregisteret-utils';
 import { withAuthenticatedApi } from '../../auth/withAuthentication';
+import { brukerMock } from '@/config/env';
 
-const brukerMock = process.env.NEXT_PUBLIC_ENABLE_MOCK === 'enabled';
 const PERIODER_URL = `${process.env.ARBEIDSSOKERREGISTERET_OPPSLAG_API_V2_URL}/api/v1/arbeidssoekerperioder`;
 const OPPLYSNINGER_URL = `${process.env.ARBEIDSSOKERREGISTERET_OPPSLAG_API_V2_URL}/api/v1/opplysninger-om-arbeidssoeker`;
 

--- a/src/pages/api/sistearbeidsforhold-fra-aareg-v2.ts
+++ b/src/pages/api/sistearbeidsforhold-fra-aareg-v2.ts
@@ -7,8 +7,7 @@ import { getAaregToken, getHeaders, getTokenFromRequest } from '../../lib/next-a
 import { withAuthenticatedApi } from '../../auth/withAuthentication';
 import { verifyToken } from '../../auth/token-validation';
 import { hentSisteArbeidsForhold } from '../../lib/hent-siste-arbeidsforhold';
-
-const brukerMock = process.env.NEXT_PUBLIC_ENABLE_MOCK === 'enabled';
+import { brukerMock } from '@/config/env';
 
 const url = brukerMock
     ? `${process.env.SISTEARBEIDSFORHOLD_FRA_AAREG_URL}`

--- a/src/pages/api/yrke-med-styrk-v2.ts
+++ b/src/pages/api/yrke-med-styrk-v2.ts
@@ -4,8 +4,6 @@ import { logger } from '@navikt/next-logger';
 
 import { withAuthenticatedApi } from '../../auth/withAuthentication';
 
-const brukerMock = process.env.NEXT_PUBLIC_ENABLE_MOCK === 'enabled';
-
 async function yrkeMedStyrk(req: NextApiRequest, res: NextApiResponse<string>) {
     const callId = nanoid();
     const yrke = req.query.yrke;


### PR DESCRIPTION
Fjerner bruk av `NEXT_PUBLIC_ENABLE_MOCK` på server-side filer, og erstatter med `ENABLE_MOCK`, som blir sentralisert i `env.ts`. En fil som kun eksporterer `process.env.ENABLE_MOCK === 'enabled'`

Ikke veldig farlig at enable-mock er/var synlig i klienten, men kan være greit å ha et tydelig skille mellom klient og server 😃 